### PR TITLE
Allow tardis-machine to accept and pass through an optional proxy argument

### DIFF
--- a/bin/tardis-machine.js
+++ b/bin/tardis-machine.js
@@ -44,6 +44,10 @@ const argv = yargs
     describe: 'Enable debug logs.',
     default: false
   })
+  .option('proxy', {
+    type: 'string',
+    describe: 'The address of the proxy server to use for external connections'
+  })
 
   .help()
   .version()
@@ -66,7 +70,8 @@ async function start() {
   const machine = new TardisMachine({
     apiKey: argv['api-key'],
     cacheDir: argv['cache-dir'],
-    clearCache: argv['clear-cache']
+    clearCache: argv['clear-cache'],
+    proxy: argv['proxy'],
   })
   let suffix = ''
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^4.3.1",
     "find-my-way": "^4.1.0",
     "is-docker": "^2.2.1",
-    "tardis-dev": "file:../tardis-node",
+    "tardis-dev": "^12.5.12",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v19.2.0",
     "yargs": "^17.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "debug": "^4.3.1",
     "find-my-way": "^4.1.0",
     "is-docker": "^2.2.1",
-    "tardis-dev": "^12.5.8",
+    "tardis-dev": "file:../tardis-node",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#v19.2.0",
     "yargs": "^17.0.1"
   },

--- a/src/tardismachine.ts
+++ b/src/tardismachine.ts
@@ -15,6 +15,7 @@ export class TardisMachine {
     init({
       apiKey: options.apiKey,
       cacheDir: options.cacheDir,
+      proxy: options.proxy,
       _userAgent: `tardis-machine/${pkg.version} (+https://github.com/tardis-dev/tardis-machine)`
     })
 
@@ -109,4 +110,5 @@ type Options = {
   apiKey?: string
   cacheDir: string
   clearCache?: boolean
+  proxy?: string
 }


### PR DESCRIPTION
This extends support for using `tardis-machine` and `tardis-node` from behind a corporate proxy.

- Additional `--proxy` argument which feeds through to the `tardis-node` `Options` object.

Note the `package.json` dependency on `tardis-node` will need updating to reference the appropriate version of `tardis-node` once that has support for proxy configuration.